### PR TITLE
API call limit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ shopify.order.list({ limit: 5 })
   .catch(err => console.error(err));
 ```
 
+You can access your current call limits with `shopify.callLimits`.
+This is updated with each request to Shopify's API. Values start at undefined.
+
+```js
+console.log(shopify.callLimits)
+/*
+{
+  max: 40,
+  current: 10,
+  remaining: 30
+}
+*/
+```
+
 ### Available resources and methods
 
 - applicationCharge

--- a/index.js
+++ b/index.js
@@ -32,6 +32,15 @@ function Shopify(shop, key, password) {
     this.token = key;
   }
 
+  //
+  // API call limits, updated with each request.
+  //
+  this.callLimits = {
+    max: undefined,
+    current: undefined,
+    remaining: undefined
+  };
+
   this.baseUrl = {
     hostname: `${shop}.myshopify.com`,
     protocol: 'https:',
@@ -68,6 +77,16 @@ Shopify.prototype.request = function request(url, method, key, params) {
 
   return got(options).then(res => {
     const body = res.body;
+
+    const callLimitHeader = res.headers['x-shopify-shop-api-call-limit'];
+
+    if (callLimitHeader) {
+      const callLimits = this.callLimits;
+      const splitLimit = callLimitHeader.split('/');
+      callLimits.max = +splitLimit[1];
+      callLimits.current = +splitLimit[0];
+      callLimits.remaining = callLimits.max - callLimits.current;
+    }
 
     if (key) return body[key];
     return body || {};


### PR DESCRIPTION
This adds a property to the shopify class called `callLimits`, which starts like this:

```js
{
  max: undefined,
  current: undefined,
  remaining: undefined
}
```

and after each request, looks like this:

```js
{
  max: 40,
  current: 6,
  remaining: 34
}
```

If the `x-shopify-shop-api-call-limit` header does not exist (is not a string), values don't get updated.

Ref: https://docs.shopify.com/api/guides/api-call-limit#how-to-avoid-the-429-error