### PR TITLE
[major] Construct with options object, instead of argument list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,37 +15,48 @@ $ npm install --save shopify-api-node
 
 ## Usage:
 
-This module exports a constructor function which takes three or two arguments
-depending if you want to use it for private or public apps.
+This module exports a constructor function which takes an options object,
+requirements depending if you want to use it for private or public apps.
 
 ### Private apps
 
-For [private][generate-private-app-credentials] apps use three arguments:
+For [private][generate-private-app-credentials] apps use
+the `shopName`, `apiKey`, and `password` options:
 
 ```js
 const Shopify = require('shopify-api-node');
 
-const shopify = new Shopify(shopName, apiKey, password);
+const shopify = new Shopify({
+  shopName: 'your-shop-name',
+  apiKey: 'your-api-key',
+  password: 'your-app-password'
+});
 ```
 
 ### Public apps
 
-For public apps use two arguments:
+For public apps use the `shopName` and `accessToken` options:
 
 ```js
 const Shopify = require('shopify-api-node');
 
-const shopify = new Shopify(shopName, token);
+const shopify = new Shopify({
+  shopName: 'your-shop-name',
+  accessToken: 'your-oauth-token'
+});
 ```
 
-where `token` is a persistent [OAuth 2.0][oauth] token.
+where `accessToken` is a persistent [OAuth 2.0][oauth] token.
 
 ### Resources
 
 Every resource is accessed via your `shopify` instance:
 
 ```js
-const shopify = new Shopify(shopName, token);
+const shopify = new Shopify({
+  shopName: 'your-shop-name',
+  accessToken: 'your-oauth-token'
+});
 
 // shopify.<resouce_name>.<method_name>
 ```

--- a/index.js
+++ b/index.js
@@ -11,25 +11,32 @@ const pkg = require('./package');
 /**
  * Creates a Shopify instance.
  *
- * @param {String} shop The name of the shop
- * @param {String} key The API Key
- * @param {String} password The password
+ * @param {Object} options Options object.
+ * @param {String} options.shopName The name of the shop
+ * @param {String} options.apiKey The API Key
+ * @param {String} options.password The private app password
+ * @param {String} options.accessToken The persistent OAuth public app token
  * @constructor
  * @public
  */
-function Shopify(shop, key, password) {
-  if (!(this instanceof Shopify)) return new Shopify(shop, key, password);
-  if (!shop || !key) throw new Error('Missing required arguments');
+function Shopify(options) {
+  if (!(this instanceof Shopify)) return new Shopify(options);
+  if (!options || !options.shopName) {
+    throw new Error('Missing required shopName option');
+  }
 
   let auth;
 
   //
-  // If we have only 2 arguments, `key` is a persistent OAuth2 token.
+  // If we have apiKey, we also need password
+  // otherwise, we just need token
   //
-  if (password) {
-    auth = `${key}:${password}`;
+  if (options.apiKey && options.password) {
+    auth = `${options.apiKey}:${options.password}`;
+  } else if (options.accessToken) {
+    this.token = options.accessToken;
   } else {
-    this.token = key;
+    throw new Error('Missing required options');
   }
 
   //
@@ -42,7 +49,7 @@ function Shopify(shop, key, password) {
   };
 
   this.baseUrl = {
-    hostname: `${shop}.myshopify.com`,
+    hostname: `${options.shopName}.myshopify.com`,
     protocol: 'https:',
     auth
   };

--- a/test/common.js
+++ b/test/common.js
@@ -10,7 +10,7 @@ const password = '72297d971271bc62ca899bba7432acb1';
 const apiKey = 'bc731e500840231da5b43bb3f388d2f0';
 const shopName ='johns-apparel';
 
-const shopify = new Shopify(shopName, accessToken);
+const shopify = new Shopify({ shopName, accessToken });
 
 const scope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -24,25 +24,27 @@ describe('Shopify', () => {
   it('throws an error when required constructor arguments are missing', () => {
     expect(() => {
       new Shopify();
-    }).to.throw(/Missing required arguments/);
+    }).to.throw(/Missing required shopName option/);
 
     expect(() => {
-      new Shopify(shopName);
-    }).to.throw(/Missing required arguments/);
+      new Shopify({ shopName });
+    }).to.throw(
+      /Missing required options/
+    );
 
     expect(() => {
-      new Shopify('', apiKey);
-    }).to.throw(/Missing required arguments/);
+      new Shopify({ apiKey });
+    }).to.throw(/Missing required shopName option/);
   });
 
   it('makes the new operator optional', () => {
-    const shopify = Shopify(shopName, accessToken);
+    const shopify = Shopify({ shopName, accessToken });
 
     expect(shopify).to.be.an.instanceof(Shopify);
   });
 
   it('adds basic auth to the URL when using apiKey and password', () => {
-    const shopify = new Shopify(shopName, apiKey, password);
+    const shopify = new Shopify({ shopName, apiKey, password });
 
     expect(shopify.baseUrl).to.deep.equal({
       hostname: `${shopName}.myshopify.com`,
@@ -52,7 +54,7 @@ describe('Shopify', () => {
   });
 
   it('does not add basic auth to the URL when using an access token', () => {
-    const shopify = new Shopify(shopName, accessToken);
+    const shopify = new Shopify({ shopName, accessToken });
 
     expect(shopify.baseUrl).to.deep.equal({
       hostname: `${shopName}.myshopify.com`,
@@ -62,7 +64,7 @@ describe('Shopify', () => {
   });
 
   it('instantiates the resources lazily', () => {
-    const shopify = new Shopify(shopName, accessToken);
+    const shopify = new Shopify({ shopName, accessToken });
 
     expect(shopify.hasOwnProperty('blog')).to.be.false;
 
@@ -74,7 +76,7 @@ describe('Shopify', () => {
   });
 
   it('allows to manually instantiate a resource', () => {
-    const shopify = new Shopify(shopName, accessToken);
+    const shopify = new Shopify({ shopName, accessToken });
     const blog = new Blog(shopify);
 
     expect(shopify.hasOwnProperty('blog')).to.be.false;
@@ -86,7 +88,7 @@ describe('Shopify', () => {
   });
 
   it('has undefined callLimit values for the initial instance', () => {
-    const shopify = new Shopify(shopName, accessToken);
+    const shopify = new Shopify({ shopName, accessToken });
 
     expect(shopify.callLimits).to.deep.equal({
       remaining: undefined,
@@ -143,7 +145,7 @@ describe('Shopify', () => {
     });
 
     it('uses basic auth as intended', () => {
-      const shopify = new Shopify(shopName, apiKey, password);
+      const shopify = new Shopify({ shopName, apiKey, password });
       const url = assign({ path: '/test' }, shopify.baseUrl);
 
       nock(`https://${shopName}.myshopify.com`, {


### PR DESCRIPTION
Precursor to adding the `timeout` parameter to options object.

Ref: #96 